### PR TITLE
Add command for `HTTP Cookie` debugging

### DIFF
--- a/src/cookie.py
+++ b/src/cookie.py
@@ -1,0 +1,74 @@
+import lldb
+import shlex
+import argparse
+from typing import Union, cast
+import util
+
+
+def __lldb_init_module(debugger: lldb.SBDebugger, internal_dict: dict) -> None:
+    debugger.HandleCommand('command script add -f cookie.handle_command cookie -h "HTTP Cookie debugging[iLLDB]"')
+
+
+def handle_command(
+        debugger: lldb.SBDebugger,
+        command: str,
+        exe_ctx: lldb.SBExecutionContext,
+        result: lldb.SBCommandReturnObject,
+        internal_dict: dict) -> None:
+    args: Union[list[str], argparse.Namespace] = shlex.split(command, posix=False)
+    args = parse_args(cast(list[str], args))
+
+    if args.subcommand == "read":
+        read(args, debugger, result)
+
+
+def parse_args(args: list[str]) -> argparse.Namespace:
+    description = "HTTP Cookie debugging"
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=util.HelpFormatter)
+    subparsers = parser.add_subparsers(title="Subcommands", dest="subcommand")
+
+    # read
+    read_command = subparsers.add_parser("read",
+                                         help="Read Cookie value",
+                                         formatter_class=util.HelpFormatter)
+    read_command.add_argument("--group-id", type=str, help="AppGroup identifier for cookie storage")
+    read_command.add_argument("--domain", type=str, help="Domain for Cookie")
+    read_command.add_argument("--name", type=str, help="Name for Cookie")
+    read_command.add_argument("--path", type=str, help="Path for Cookie")
+
+    return parser.parse_args(args)
+
+
+def read(args: argparse.Namespace, debugger: lldb.SBDebugger, result: lldb.SBCommandReturnObject) -> None:
+    script = "@import Foundation;\n"
+    if args.group_id is not None:
+        script += f'NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier:@"{args.group_id}"];\n'
+    else:
+        script += "NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];\n"
+
+    script += util.read_script_file('objc/cookie_read.m')
+
+    # domain
+    if args.domain is not None:
+        script = script.replace("<DOMAIN>", args.domain)
+    else:
+        script = script.replace("@\"<DOMAIN>\"", "NULL")
+
+    # name
+    if args.name is not None:
+        script = script.replace("<NAME>", args.name)
+    else:
+        script = script.replace("@\"<NAME>\"", "NULL")
+
+    # path
+    if args.path is not None:
+        script = script.replace("<PATH>", args.path)
+    else:
+        script = script.replace("@\"<PATH>\"", "NULL")
+
+    _ = util.exp_script(
+        debugger,
+        script,
+        lang=lldb.eLanguageTypeObjC
+    )

--- a/src/cookie.py
+++ b/src/cookie.py
@@ -20,6 +20,13 @@ def handle_command(
 
     if args.subcommand == "read":
         read(args, debugger, result)
+    elif args.subcommand == "delete":
+        read(args, debugger, result)
+        confirm = input('The above cookies will be deleted. Please type "Yes" if OK\n')
+        if confirm == "Yes":
+            delete(args, debugger, result)
+        else:
+            print("Cancelled")
 
 
 def parse_args(args: list[str]) -> argparse.Namespace:
@@ -37,17 +44,60 @@ def parse_args(args: list[str]) -> argparse.Namespace:
     read_command.add_argument("--name", type=str, help="Name for Cookie")
     read_command.add_argument("--path", type=str, help="Path for Cookie")
 
+    # delete
+    delete_command = subparsers.add_parser("delete",
+                                           help="Delete Cookie",
+                                           formatter_class=util.HelpFormatter)
+    delete_command.add_argument("--group-id", type=str, help="AppGroup identifier for cookie storage")
+    delete_command.add_argument("--domain", type=str, help="Domain for Cookie")
+    delete_command.add_argument("--name", type=str, help="Name for Cookie")
+    delete_command.add_argument("--path", type=str, help="Path for Cookie")
+
     return parser.parse_args(args)
 
 
 def read(args: argparse.Namespace, debugger: lldb.SBDebugger, result: lldb.SBCommandReturnObject) -> None:
-    script = "@import Foundation;\n"
+    script = ""
     if args.group_id is not None:
         script += f'NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier:@"{args.group_id}"];\n'
     else:
         script += "NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];\n"
 
     script += util.read_script_file('objc/cookie_read.m')
+
+    # domain
+    if args.domain is not None:
+        script = script.replace("<DOMAIN>", args.domain)
+    else:
+        script = script.replace("@\"<DOMAIN>\"", "NULL")
+
+    # name
+    if args.name is not None:
+        script = script.replace("<NAME>", args.name)
+    else:
+        script = script.replace("@\"<NAME>\"", "NULL")
+
+    # path
+    if args.path is not None:
+        script = script.replace("<PATH>", args.path)
+    else:
+        script = script.replace("@\"<PATH>\"", "NULL")
+
+    _ = util.exp_script(
+        debugger,
+        script,
+        lang=lldb.eLanguageTypeObjC
+    )
+
+
+def delete(args: argparse.Namespace, debugger: lldb.SBDebugger, result: lldb.SBCommandReturnObject) -> None:
+    script = ""
+    if args.group_id is not None:
+        script += f'NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier:@"{args.group_id}"];\n'
+    else:
+        script += "NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];\n"
+
+    script += util.read_script_file('objc/cookie_delete.m')
 
     # domain
     if args.domain is not None:

--- a/src/objc/cookie_delete.m
+++ b/src/objc/cookie_delete.m
@@ -10,8 +10,6 @@ NSString *path = @"<PATH>";
 NSArray *allCookies = [storage cookies];
 int matchedCount = 0;
 
-printf("Cookie Information:\n");
-
 for (NSHTTPCookie *cookie in allCookies) {
   BOOL domainMatched =
       (domain == nil) || [cookie.domain isEqualToString:domain];
@@ -19,23 +17,11 @@ for (NSHTTPCookie *cookie in allCookies) {
   BOOL pathMatched = (path == nil) || [cookie.path isEqualToString:path];
 
   if (domainMatched && nameMatched && pathMatched) {
-    printf("-------------------\n");
-
-    printf("  Name:    %s\n", (char *)[cookie.name UTF8String]);
-    printf("  Value:   %s\n", (char *)[cookie.value UTF8String]);
-    printf("  Domain:  %s\n", (char *)[cookie.domain UTF8String]);
-    printf("  Path:    %s\n", (char *)[cookie.path UTF8String]);
-
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
-    NSString *formattedDate = [dateFormatter stringFromDate:cookie.expiresDate];
-    printf("  Expires: %s\n", (char *)[formattedDate UTF8String]);
-
-    printf("-------------------\n");
+    [storage deleteCookie:cookie];
     matchedCount++;
   }
 }
 
 if (matchedCount == 0) {
-  printf("  None\n");
+  printf("%d Cookies was deleted\n", matchedCount);
 }

--- a/src/objc/cookie_read.m
+++ b/src/objc/cookie_read.m
@@ -1,0 +1,41 @@
+@import Foundation;
+
+// #import <Foundation/Foundation.h>
+// NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+
+NSString *domain = @"<DOMAIN>";
+NSString *name = @"<NAME>";
+NSString *path = @"<PATH>";
+
+NSArray *allCookies = [storage cookies];
+int matchedCount = 0;
+
+printf("Cookie Information:\n");
+
+for (NSHTTPCookie *cookie in allCookies) {
+  BOOL domainMatched =
+      (domain == nil) || [cookie.domain isEqualToString:domain];
+  BOOL nameMatched = (name == nil) || [cookie.name isEqualToString:name];
+  BOOL pathMatched = (path == nil) || [cookie.path isEqualToString:path];
+
+  if (domainMatched && nameMatched && pathMatched) {
+    printf("-------------------\n");
+
+    printf("  Name:    %s\n", (char *)[cookie.name UTF8String]);
+    printf("  Value:   %s\n", (char *)[cookie.value UTF8String]);
+    printf("  Domain:  %s\n", (char *)[cookie.domain UTF8String]);
+    printf("  Path:    %s\n", (char *)[cookie.path UTF8String]);
+
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+    NSString *formattedDate = [dateFormatter stringFromDate:cookie.expiresDate];
+    printf("  Expires: %s\n", (char *)[formattedDate UTF8String]);
+
+    printf("-------------------\n");
+    matchedCount++;
+  }
+}
+
+if (matchedCount == 0) {
+  printf("  None\n")
+}

--- a/src/objc/cookie_read.m
+++ b/src/objc/cookie_read.m
@@ -25,6 +25,7 @@ for (NSHTTPCookie *cookie in allCookies) {
     printf("  Value:   %s\n", (char *)[cookie.value UTF8String]);
     printf("  Domain:  %s\n", (char *)[cookie.domain UTF8String]);
     printf("  Path:    %s\n", (char *)[cookie.path UTF8String]);
+    printf("  Secure:  %s\n", cookie.secure ? "True" : "False");
 
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];

--- a/src/ui.py
+++ b/src/ui.py
@@ -98,7 +98,7 @@ def tree(args: argparse.Namespace, debugger: lldb.SBDebugger, result: lldb.SBCom
     )
 
 
-def resolve_adress(args: argparse.Namespace):
+def resolve_adress(args: argparse.Namespace) -> None:
     try:
         if args.window is not None and int(args.window, 16):
             args.window = f"Unmanaged<NSUIWindow>.fromOpaque(.init(bitPattern: {args.window})!).takeUnretainedValue()"


### PR DESCRIPTION
closes #17 

```
(lldb) cookie -h
usage: 
       [-h]
       {read,delete}
       ...
HTTP Cookie debugging
optional arguments:
  -h, --help
    show this help message and exit
Subcommands:
  {read,delete}
    read
    Read Cookie value
    delete
    Delete Cookie
```