### PR TITLE
Add `path` option to `file tree` and `file open` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,15 +201,17 @@ app info
 (lldb) file tree -h
 usage:  tree
        [-h]
+       [-p PATH]
        [-b]
        [-l]
        [--documents]
        [--tmp]
        [--depth DEPTH]
-
 optional arguments:
   -h, --help
     show this help message and exit
+  -p PATH, --path PATH
+    path (default: None)
   -b, --bundle
     bundle directory (default: False)
   -l, --library
@@ -262,21 +264,24 @@ optional arguments:
 (lldb) file open -h
 usage:  open
        [-h]
+       [-p PATH]
        [-b]
        [-l]
        [--documents]
-       [--tmp TMP]
+       [--tmp]
 optional arguments:
   -h, --help
     show this help message and exit
+  -p PATH, --path PATH
+    path (default: None)
   -b, --bundle
     bundle directory (default: False)
   -l, --library
     library directory (default: False)
   --documents
     documents directory (default: False)
-  --tmp TMP
-    tmp directory (default: None)
+  --tmp
+    tmp directory (default: False)
 ```
 
 ### Show file Contents

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ optional arguments:
 - Display the contents of a specific directory
 
     ```sh
-    file tree {url}
+    file tree --path {url}
     ```
 
 ![file tree](./resources/file-tree.png)

--- a/src/file.py
+++ b/src/file.py
@@ -30,6 +30,7 @@ class FileCommnad(LLDBCommandBase):
         tree_command = subparsers.add_parser("tree",
                                              help="Show file hierarchie",
                                              formatter_class=util.HelpFormatter)
+        tree_command.add_argument("-p", "--path", type=str, help="path")
         tree_command.add_argument("-b", "--bundle", action="store_true", help="bundle directory")
         tree_command.add_argument("-l", "--library", action="store_true", help="library directory")
         tree_command.add_argument("--documents", action="store_true", help="documents directory")
@@ -39,6 +40,7 @@ class FileCommnad(LLDBCommandBase):
         open_command = subparsers.add_parser("open",
                                              help="Open directory with Finder (Simulator Only)",
                                              formatter_class=util.HelpFormatter)
+        open_command.add_argument("-p", "--path", type=str, required=False, help="path")
         open_command.add_argument("-b", "--bundle", action="store_true", help="bundle directory")
         open_command.add_argument("-l", "--library", action="store_true", help="library directory")
         open_command.add_argument("--documents", action="store_true", help="documents directory")
@@ -92,7 +94,10 @@ class FileCommnad(LLDBCommandBase):
         elif args.tmp:
             script += f"listFilesInDirectory(FileManager.default.temporaryDirectory, depth: {depth})"
         elif args.path:
-            script += f"listFilesInDirectory(URL(fileURLWithPath: {args.path}), depth: {depth})"
+            path: str = args.path
+            if not path.startswith('"') and not path.endswith('"'):
+                path = f"\"{path}\""
+            script += f"listFilesInDirectory(URL(fileURLWithPath: {path}), depth: {depth})"
 
         _ = util.exp_script(
             debugger,
@@ -116,7 +121,10 @@ class FileCommnad(LLDBCommandBase):
         elif args.tmp:
             script += "FileManager.default.temporaryDirectory.path"
         elif args.path:
-            shell += f"{args.path}"
+            path: str = args.path
+            if not path.startswith('"') and not path.endswith('"'):
+                path = f"\"{path}\""
+            shell += f"{path}"
 
         if script != "":
             ret = util.exp_script(debugger, script)


### PR DESCRIPTION
I forgot to add the `--path` option.